### PR TITLE
Update rbuilder version and refactor image dependencies 

### DIFF
--- a/recipes-core/images/cvm-initramfs.bbappend
+++ b/recipes-core/images/cvm-initramfs.bbappend
@@ -1,2 +1,1 @@
 PACKAGE_INSTALL:append = " rbuilder"
-IMAGE_FEATURES:append = "debug-tweaks"

--- a/recipes-core/images/cvm-initramfs.bbappend
+++ b/recipes-core/images/cvm-initramfs.bbappend
@@ -1,0 +1,2 @@
+PACKAGE_INSTALL:append = " rbuilder"
+IMAGE_FEATURES:append = "debug-tweaks"

--- a/recipes-nodes/config-parser/config-parser.bb
+++ b/recipes-nodes/config-parser/config-parser.bb
@@ -10,8 +10,23 @@ SRC_URI = "file://config_parser.sh \
 
 S = "${WORKDIR}"
 
-# Default value for the config URL
-CLOUD_INIT_CONFIG_URL ?= "http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text"
+python () {
+    # Check if CLOUD_INIT_CONFIG_URL is set in the environment or in local.conf
+    cloud_init_config_url = d.getVar('CLOUD_INIT_CONFIG_URL')
+    
+    if cloud_init_config_url is None:
+        # If not set, check the original environment
+        origenv = d.getVar("BB_ORIGENV", False)
+        if origenv:
+            cloud_init_config_url = origenv.getVar('CLOUD_INIT_CONFIG_URL')
+    
+    if cloud_init_config_url:
+        # If CLOUD_INIT_CONFIG_URL is set (to any non-empty value), keep its value
+        d.setVar('CLOUD_INIT_CONFIG_URL', cloud_init_config_url)
+    else:
+        # If CLOUD_INIT_CONFIG_URL is not set, set it to Azures default cloud-init URL
+        d.setVar('CLOUD_INIT_CONFIG_URL', 'http://169.254.169.254/metadata/instance/compute/userData?api-version=2021-01-01&format=text')
+}
 
 do_install() {
     # Create necessary directories

--- a/recipes-nodes/rbuilder/rbuilder_dev.bb
+++ b/recipes-nodes/rbuilder/rbuilder_dev.bb
@@ -4,8 +4,8 @@ LICENSE = "CLOSED"
 
 include rbuilder.inc
 
-SRC_URI = "git://github.com/flashbots/rbuilder;protocol=https;tag=v0.1.0;branch=develop"
-SRCREV = "v0.1.0"
+SRC_URI = "git://github.com/flashbots/rbuilder;protocol=https;branch=develop"
+SRCREV = "18875a4d62606290dfaebfa900cc91738fb08832"
 
 PV = "1.0+git${SRCPV}"
 


### PR DESCRIPTION
This PR does the following:
- update the rbuilder to the version where I added the parsing of CL nodes from env variable/cloud init config.
- decouples the the meta-confidential-compute layer by appending the rbuilder to the image when adding the meta-evm layer.
This way, no need to manually change the dependencies in initramfs from within the meta-confidential-layer everytime. 
In other words, modularity and better maintainability when developing for different purposes as we are doing in the BOB searcher project 