### PR TITLE
feat: run rbuilder and reth within their own users and having a common group 

### DIFF
--- a/recipes-nodes/eth-group/eth-group.bb
+++ b/recipes-nodes/eth-group/eth-group.bb
@@ -1,0 +1,12 @@
+SUMMARY = "Ethereum services group"
+DESCRIPTION = "Creates a common group for Ethereum-related services"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit useradd
+
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM:${PN} = "-r eth"
+
+do_install[noexec] = "1"
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -19,6 +19,8 @@ LOGFILE_PROXY=/tmp/proxy.log
 LOGFILE_MONITOR=/tmp/rbuilder_monitor.log
 PIDFILE=/var/run/rbuilder.pid
 PIDFILE_PROXY=/var/run/proxy.pid
+RBUILDER_USER=rbuilder
+ETH_GROUP=eth
 
 monitor_and_restart() {
     while true; do
@@ -33,7 +35,7 @@ monitor_and_restart() {
 
 start_proxy() {
     echo -n "Starting attested TLS Proxy: "
-    start-stop-daemon -S -p $PIDFILE_PROXY -N -10 -b -a /bin/sh -- -c "exec 
+    start-stop-daemon -S -p $PIDFILE_PROXY -c $RBUILDER_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec 
         ${DAEMON_PROXY} -server -target-port=8645 -listen-port=8745 \
         2>&1 | tee ${LOGFILE_PROXY}"
     echo "proxy."
@@ -43,7 +45,7 @@ start_builder() {
     # fetch the env variables that contains the secrets for the rbuilder
 	source /usr/bin/setup_env.sh
     
-	start-stop-daemon -S -p $PIDFILE -N -10 -b -a /bin/sh -- -c "exec 
+    start-stop-daemon -S -p $PIDFILE -c $RBUILDER_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec 
         ${DAEMON} run /etc/rbuilder.config \
         2>&1 | tee ${LOGFILE}"
 }
@@ -63,7 +65,7 @@ start() {
     start_proxy
     
     # Start the monitor in the background
-    monitor_and_restart &
+    su - $RBUILDER_USER -s /bin/sh -c "$(declare -f monitor_and_restart); monitor_and_restart" &
 }
 
 stop() {

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -20,6 +20,8 @@ PIDFILE=/var/run/rbuilder.pid
 PIDFILE_PROXY=/var/run/proxy.pid
 RBUILDER_USER=rbuilder
 ETH_GROUP=eth
+RETH_DIR=/persistent/reth
+RETH_USER=reth
 
 monitor_and_restart() {
     while true; do
@@ -34,7 +36,7 @@ monitor_and_restart() {
 
 start_proxy() {
     echo -n "Starting attested TLS Proxy: "
-    start-stop-daemon -S -p $PIDFILE_PROXY -c $RBUILDER_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec 
+    start-stop-daemon -S -p $PIDFILE_PROXY -N -10 -b -a /bin/sh -- -c "exec 
         ${DAEMON_PROXY} -server -target-port=8645 -listen-port=8745 \
         2>&1 | tee ${LOGFILE_PROXY}"
     echo "proxy."
@@ -51,13 +53,16 @@ start_builder() {
 
 start() {
     echo -n "Starting $DESC: "
-	# Specify the directory path you're waiting for
-    target_directory="/persistent/reth/static_files/"
 
-    while [ ! -d "$target_directory" ]; do
-        echo "Waiting for directory: $target_directory"
-        sleep 1
-    done
+    # Ensure the RETH_DIR and all subdirectories have correct permissions
+    chown -R $RETH_USER:$ETH_GROUP $RETH_DIR
+    # A hack to allow rbuilder's user to access reth via group permissions
+    chmod 770 $RETH_DIR
+    chmod 770 $RETH_DIR/static_files
+    chmod 770 $RETH_DIR/db
+    chmod 660 $RETH_DIR/db/mdbx.lck
+    chmod 660 $RETH_DIR/db/mdbx.dat
+    chmod 660 /tmp/reth.ipc
 
     start_builder
     echo "$NAME."

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 ### BEGIN INIT INFO
 # Provides:        rbuilder
 # Required-Start:  $remote_fs $syslog $networking reth
@@ -65,7 +64,7 @@ start() {
     start_proxy
     
     # Start the monitor in the background
-    su - $RBUILDER_USER -s /bin/sh -c "$(declare -f monitor_and_restart); monitor_and_restart" &
+    monitor_and_restart &
 }
 
 stop() {

--- a/recipes-nodes/rbuilder/rbuilder.inc
+++ b/recipes-nodes/rbuilder/rbuilder.inc
@@ -3,13 +3,13 @@ DESCRIPTION = "Rust builder running with a full ethereum node (reth) implemented
 LICENSE="CLOSED"
 LIC_FILES_CHKSUM=""
 
-inherit cargo_bin update-rc.d
+inherit cargo_bin update-rc.d useradd
 
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
 
-DEPENDS += "libffi openssl"
-RDEPENDS:${PN} += "libffi openssl reth cvm-reverse-proxy config-parser date-sync"
+DEPENDS += "libffi openssl eth-group"
+RDEPENDS:${PN} += "libffi openssl eth-group reth cvm-reverse-proxy config-parser"
 
 export BINDGEN_EXTRA_CLANG_ARGS
 BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${WORKDIR}/recipe-sysroot -I${WORKDIR}/recipe-sysroot/usr/include"
@@ -27,10 +27,19 @@ FILES:${PN} += "${sysconfdir}/init.d/rbuilder"
 FILES:${PN} += "${sysconfdir}/rbuilder.config"
 FILES:${PN} += "${sysconfdir}/rbuilder.ofac.json"
 
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "-r -s /bin/false -G eth rbuilder"
+
 do_install:append() {
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${THISDIR}/init ${D}${sysconfdir}/init.d/rbuilder
-    install -m 0755 ${THISDIR}/config ${D}${sysconfdir}/rbuilder.config
-    install -m 0755 ${THISDIR}/ofac.json ${D}${sysconfdir}/rbuilder.ofac.json
+    
+    # Install config files owned by root, readable by rbuilder
+    install -m 0744 ${THISDIR}/config ${D}${sysconfdir}/rbuilder.config
+    install -m 0744 ${THISDIR}/ofac.json ${D}${sysconfdir}/rbuilder.ofac.json
+
+    # Ensure rbuilder can read these files
+    chgrp rbuilder ${D}${sysconfdir}/rbuilder.config
+    chgrp rbuilder ${D}${sysconfdir}/rbuilder.ofac.json
 }
 TOOLCHAIN = "clang"

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -44,6 +44,16 @@ start() {
     --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/\$LATEST_META/ $RETH_DIR
 	" >> $LOGFILE 2>&1
 
+	# Ensure the RETH_DIR and all subdirectories have correct permissions
+	chown -R $RETH_USER:$ETH_GROUP $RETH_DIR
+	# A hack to allow rbuilder's user to access reth via group permissions
+	chmod 770 $RETH_DIR
+	chmod 770 $RETH_DIR/static_files
+	chmod 770 $RETH_DIR/db
+	chmod 660 $RETH_DIR/db/mdbx.lck
+	chmod 660 $RETH_DIR/db/mdbx.dat
+	chmod 660 /tmp/reth.ipc
+
 	echo "Reth is synced with the latest meta version: $LATEST_META"
 	echo "$NAME."
 }

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -15,6 +15,8 @@ NAME=reth-sync
 LOGFILE=/tmp/reth-sync.log
 RCLONE_CONFIG=/etc/rclone.conf
 RETH_DIR=/persistent/reth
+RETH_USER=reth
+RETH_GROUP=reth
 
 start() {
 	echo -n "Starting $DESC: "
@@ -27,11 +29,21 @@ start() {
 		exit 0
 	fi
 
-    LATEST_META=$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
+    # Ensure the RETH_DIR exists and has correct permissions
+    mkdir -p $RETH_DIR
+    chown $RETH_USER:$RETH_GROUP $RETH_DIR
+
+    # Run the sync process as the reth user
+	su - $RETH_USER -s /bin/sh -c "
+    set -x  # This will print each command as it's executed
+    LATEST_META=\$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
+    echo \"Latest meta: \$LATEST_META\"
     rclone sync --config $RCLONE_CONFIG -v -P --transfers=20 --multi-thread-streams 30 \
-	--contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
-	--delete-during --disable-http2 --no-gzip-encoding \
-	--exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/$LATEST_META/ $RETH_DIR
+    --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
+    --delete-during --disable-http2 --no-gzip-encoding \
+    --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/\$LATEST_META/ $RETH_DIR
+	" >> $LOGFILE 2>&1
+	
 	echo "Reth is synced with the latest meta version: $LATEST_META"
 	echo "$NAME."
 }

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -16,7 +16,7 @@ LOGFILE=/tmp/reth-sync.log
 RCLONE_CONFIG=/etc/rclone.conf
 RETH_DIR=/persistent/reth
 RETH_USER=reth
-RETH_GROUP=reth
+ETH_GROUP=eth
 
 start() {
 	echo -n "Starting $DESC: "
@@ -31,7 +31,7 @@ start() {
 
     # Ensure the RETH_DIR exists and has correct permissions
     mkdir -p $RETH_DIR
-    chown $RETH_USER:$RETH_GROUP $RETH_DIR
+    chown $RETH_USER:$ETH_GROUP $RETH_DIR
 
     # Run the sync process as the reth user
 	su - $RETH_USER -s /bin/sh -c "
@@ -43,7 +43,7 @@ start() {
     --delete-during --disable-http2 --no-gzip-encoding \
     --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/\$LATEST_META/ $RETH_DIR
 	" >> $LOGFILE 2>&1
-	
+
 	echo "Reth is synced with the latest meta version: $LATEST_META"
 	echo "$NAME."
 }

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -42,20 +42,8 @@ start() {
     --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
     --delete-during --disable-http2 --no-gzip-encoding \
     --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/\$LATEST_META/ $RETH_DIR
+	echo \"Reth is synced with the latest meta version: $LATEST_META\"
 	" >> $LOGFILE 2>&1
-
-	# Ensure the RETH_DIR and all subdirectories have correct permissions
-	chown -R $RETH_USER:$ETH_GROUP $RETH_DIR
-	# A hack to allow rbuilder's user to access reth via group permissions
-	chmod 770 $RETH_DIR
-	chmod 770 $RETH_DIR/static_files
-	chmod 770 $RETH_DIR/db
-	chmod 660 $RETH_DIR/db/mdbx.lck
-	chmod 660 $RETH_DIR/db/mdbx.dat
-	chmod 660 /tmp/reth.ipc
-
-	echo "Reth is synced with the latest meta version: $LATEST_META"
-	echo "$NAME."
 }
 
 

--- a/recipes-nodes/reth-sync/reth-sync.bb
+++ b/recipes-nodes/reth-sync/reth-sync.bb
@@ -11,7 +11,7 @@ INITSCRIPT_PARAMS = "defaults 96"
 inherit update-rc.d useradd
 
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM:${PN} = "-r -s /bin/false -U reth"
+USERADD_PARAM:${PN} = "-r -s /bin/false -G eth reth"
 
 do_install() {
     install -d ${D}${sysconfdir}/init.d
@@ -20,8 +20,10 @@ do_install() {
     
     # Create directory for reth data
     install -d ${D}/persistent/reth
-    chown reth:reth ${D}/persistent/reth
+    chown reth:eth ${D}/persistent/reth
+    chmod 0740 ${D}/persistent/reth
 }
 
-RDEPENDS:${PN} += "rclone"
+DEPENDS += "eth-group"
+RDEPENDS:${PN} += "rclone eth-group"
 FILES:${PN} += "/persistent/reth"

--- a/recipes-nodes/reth-sync/reth-sync.bb
+++ b/recipes-nodes/reth-sync/reth-sync.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "syncs the reth state from AWS s3"
+DESCRIPTION = "Syncs the reth state from a remote snapshot"
 LICENSE = "CLOSED"
 FILESEXTRAPATHS:prepend := "${THISDIR}:"
 
@@ -8,12 +8,20 @@ SRC_URI += "file://rclone.conf"
 INITSCRIPT_NAME = "reth-sync"
 INITSCRIPT_PARAMS = "defaults 96"
 
-inherit update-rc.d
+inherit update-rc.d useradd
+
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "-r -s /bin/false -U reth"
 
 do_install() {
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${THISDIR}/init ${D}${sysconfdir}/init.d/reth-sync
     install -m 0644 ${THISDIR}/rclone.conf ${D}${sysconfdir}/rclone.conf
+    
+    # Create directory for reth data
+    install -d ${D}/persistent/reth
+    chown reth:reth ${D}/persistent/reth
 }
 
 RDEPENDS:${PN} += "rclone"
+FILES:${PN} += "/persistent/reth"

--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -1,14 +1,13 @@
 #!/bin/sh
-#
 ### BEGIN INIT INFO
-# Provides:		reth
-# Required-Start:	$remote_fs $syslog $networking
-# Required-Stop:	$remote_fs $syslog
-# Default-Start:	2 3 4 5
-# Default-Stop:		1
-# Short-Description:	Start and stop the reth daemon
+# Provides:          reth
+# Required-Start:    $network $remote_fs reth-sync
+# Required-Stop:     $network $remote_fs
+# Default-Start:     5
+# Default-Stop:      0 1 6
+# Short-Description: Reth Node
+# Description:       Start and stop the reth daemon
 ### END INIT INFO
-#
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON=/usr/bin/reth
@@ -16,16 +15,31 @@ NAME=reth
 DESC="Reth Node"
 PIDFILE=/var/run/reth.pid
 LOGFILE=/tmp/reth.log
+RETH_USER=reth
+RETH_GROUP=reth
+RETH_DIR=/persistent/reth
 
-# dd if=/dev/urandom bs=32 count=1 2>/dev/null | hexdump -v -e '1/1 "%02x"' > /var/volatile/jwt.hex
 start() {
 	echo -n "Starting $DESC: "
+	# Source the setup.env file
+	if [ -f /usr/bin/setup_env.sh ]; then
+		source /usr/bin/setup_env.sh
+	fi
+
+	# Ensure the RETH_DIR exists and has correct permissions
+	mkdir -p $RETH_DIR
+	chown $RETH_USER:$RETH_GROUP $RETH_DIR
+
+	# Set JWT_SECRET, use environment variable if set, otherwise use hardcoded value
+	JWT_SECRET=${JWT_SECRET:-"0x4c5a4856e3873434d51de798c8e4f17ca2dcc2ccd42cb72c8446db819fe69489"}
+
 	mount -o remount,size=90% /var/volatile
-	echo "0x4c5a4856e3873434d51de798c8e4f17ca2dcc2ccd42cb72c8446db819fe69489" > /var/volatile/jwt.hex
-	start-stop-daemon -S -p $PIDFILE -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
+	echo "$JWT_SECRET" > /var/volatile/jwt.hex
+	chown ${RETH_USER}:${RETH_GROUP} /var/volatile/jwt.hex
+	start-stop-daemon -S -p $PIDFILE -c $RETH_USER:$RETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
 		node \
 		--full \
-		--datadir "/persistent/reth" \
+		--datadir "$RETH_DIR" \
 		--authrpc.addr 0.0.0.0 \
 		--authrpc.jwtsecret "/var/volatile/jwt.hex" \
 		--authrpc.port 8551 \

--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -16,7 +16,7 @@ DESC="Reth Node"
 PIDFILE=/var/run/reth.pid
 LOGFILE=/tmp/reth.log
 RETH_USER=reth
-RETH_GROUP=reth
+ETH_GROUP=eth
 RETH_DIR=/persistent/reth
 
 start() {
@@ -28,15 +28,15 @@ start() {
 
 	# Ensure the RETH_DIR exists and has correct permissions
 	mkdir -p $RETH_DIR
-	chown $RETH_USER:$RETH_GROUP $RETH_DIR
+	chown $RETH_USER:$ETH_GROUP $RETH_DIR
 
 	# Set JWT_SECRET, use environment variable if set, otherwise use hardcoded value
 	JWT_SECRET=${JWT_SECRET:-"0x4c5a4856e3873434d51de798c8e4f17ca2dcc2ccd42cb72c8446db819fe69489"}
 
 	mount -o remount,size=90% /var/volatile
 	echo "$JWT_SECRET" > /var/volatile/jwt.hex
-	chown ${RETH_USER}:${RETH_GROUP} /var/volatile/jwt.hex
-	start-stop-daemon -S -p $PIDFILE -c $RETH_USER:$RETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
+	chown ${RETH_USER}:${ETH_GROUP} /var/volatile/jwt.hex
+	start-stop-daemon -S -p $PIDFILE -c $RETH_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
 		node \
 		--full \
 		--datadir "$RETH_DIR" \

--- a/recipes-nodes/reth/reth.inc
+++ b/recipes-nodes/reth/reth.inc
@@ -29,7 +29,7 @@ do_install:append() {
     # Create directory for reth data
     install -d ${D}/persistent/reth
     chown reth:eth ${D}/persistent/reth
-    chmod 0740 ${D}/persistent/reth
+    chmod 0770 ${D}/persistent/reth
 }
 
 FILES:${PN} += "/persistent/reth"

--- a/recipes-nodes/reth/reth.inc
+++ b/recipes-nodes/reth/reth.inc
@@ -19,7 +19,7 @@ INITSCRIPT_PARAMS = "defaults 98"
 S = "${WORKDIR}/git"
 
 USERADD_PACKAGES = "${PN}"
-USERADD_PARAM:${PN} = "-r -s /bin/false -U reth"
+USERADD_PARAM:${PN} = "-r -s /bin/false -G eth reth"
 
 do_install:append() {
     install -d ${D}${bindir}
@@ -28,12 +28,14 @@ do_install:append() {
     
     # Create directory for reth data
     install -d ${D}/persistent/reth
-    chown reth:reth ${D}/persistent/reth
+    chown reth:eth ${D}/persistent/reth
+    chmod 0740 ${D}/persistent/reth
 }
 
 FILES:${PN} += "/persistent/reth"
 TOOLCHAIN = "clang"
-RDEPENDS:${PN} += "disk-encryption config-parser"
+DEPENDS += "eth-group"
+RDEPENDS:${PN} += "disk-encryption config-parser eth-group"
 
 python () {
     # Check if INCLUDE_RCLONE is set in the environment or in local.conf

--- a/recipes-nodes/reth/reth.inc
+++ b/recipes-nodes/reth/reth.inc
@@ -1,9 +1,9 @@
 SUMMARY = "Reth"
 DESCRIPTION = "reth is the command line interface for running a full ethereum node implemented in rust."
-LICENSE="CLOSED"
-LIC_FILES_CHKSUM=""
+LICENSE = "CLOSED"
+LIC_FILES_CHKSUM = ""
 
-inherit cargo_bin update-rc.d
+inherit cargo_bin update-rc.d useradd
 
 # Enable network for the compile task allowing cargo to download dependencies
 do_compile[network] = "1"
@@ -18,11 +18,20 @@ INITSCRIPT_PARAMS = "defaults 98"
 
 S = "${WORKDIR}/git"
 
+USERADD_PACKAGES = "${PN}"
+USERADD_PARAM:${PN} = "-r -s /bin/false -U reth"
+
 do_install:append() {
     install -d ${D}${bindir}
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${THISDIR}/init ${D}${sysconfdir}/init.d/reth
+    
+    # Create directory for reth data
+    install -d ${D}/persistent/reth
+    chown reth:reth ${D}/persistent/reth
 }
+
+FILES:${PN} += "/persistent/reth"
 TOOLCHAIN = "clang"
 RDEPENDS:${PN} += "disk-encryption config-parser"
 


### PR DESCRIPTION
In this PR we do the follow:
1- create a recipe that creates the eth group for the process in common (rbuilder + reth)
2- create own system user for both rbuilder and reth to be executed with
3- refactor the init files 