### PR TITLE
Fix curl command for fetching the configs from BuilderHub

### DIFF
--- a/recipes-nodes/render-config/fetch-config.sh
+++ b/recipes-nodes/render-config/fetch-config.sh
@@ -11,8 +11,6 @@
 
 set -e
 
-source /etc/init-config.conf
-
 INIT_CONFIG_FILE="/etc/init-config.json"
 TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf"
 
@@ -22,8 +20,8 @@ case "$1" in
     echo "Fetching configuration..." > /var/volatile/system-api.fifo
 
     (umask 0177 && touch "${INIT_CONFIG_FILE}")
-    curl -fsSL --proxy http://localhost:7937 --retry 3 --retry-delay 60 --retry-connrefused \
-      -H "Metadata: true" -o "${INIT_CONFIG_FILE}" "${INIT_CONFIG_URL}"
+    curl -fsSL --retry 3 --retry-delay 60 --retry-connrefused \
+      -o "${INIT_CONFIG_FILE}" http://localhost:7937/api/l1-builder/v1/configuration
     if [ ! -s "${INIT_CONFIG_FILE}" ]; then
       echo "Failed to fetch configuration."
       exit 1


### PR DESCRIPTION
Ask for the config directly from the cvm-proxy since it already knows how to talk to BuilderHub