### PR TITLE
Enable dry-run mode by default for rbuilder

### DIFF
--- a/recipes-nodes/rbuilder/config.input_example
+++ b/recipes-nodes/rbuilder/config.input_example
@@ -6,6 +6,8 @@
     "optimistic_relay_secret_key": "optimistic_relay_key",
     "top_bid_stream_api_key": "string",
     "always_seal": true,
+    "dry_run": true,
+    "dry_run_validation_url": "http://localhost:8545",
     "relays": [
       {
           "name": "flashbots",

--- a/recipes-nodes/rbuilder/config.mustache
+++ b/recipes-nodes/rbuilder/config.mustache
@@ -23,7 +23,8 @@ extra_data = "{{rbuilder.extra_data}}"
 
 blocklist_file_path = "/etc/rbuilder.ofac.json"
 
-dry_run = false
+dry_run = {{rbuilder.dry_run}}
+dry_run_validation_url = {{rbuilder.dry_run_validation_url}}
 
 ignore_cancellable_orders = true
 always_seal = {{rbuilder.always_seal}}


### PR DESCRIPTION
Enable dry-run mode by default for rbuilder. We want to make sure everything is working E2E before sending to relays.