### PR TITLE
feat: Add skeleton recipe for the private bidding logic

### DIFF
--- a/recipes-nodes/rbuilder-bidding/init
+++ b/recipes-nodes/rbuilder-bidding/init
@@ -1,0 +1,118 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          rbuilder-bidding
+# Required-Start:    $remote_fs $syslog $network
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start rbuilder bidding service
+### END INIT INFO
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON= #TODO: exact podman execution command name. Needed also for the monitor_and_restart function to detect it if crashed or not
+NAME=rbuilder-bidding
+DESC="Builder Bidding Service"
+LOGFILE=/var/log/rbuilder-bidding.log
+LOGFILE_MONITOR=/var/log/rbuilder-bidding_monitor.log
+PIDFILE=/var/run/rbuilder-bidding.pid
+PIDFILE_MONITOR=/var/run/rbuilder-bidding_monitor.pid
+RBUILDER_USER=rbuilder
+ETH_GROUP=eth
+
+
+monitor_and_restart() {
+    #TODO: Make sure the podman execution command is detected correctly
+    while true; do
+        if ! pgrep -f "$DAEMON" > /dev/null; then
+            echo "$(date): $DESC crashed. Restarting in 60 seconds..." >> ${LOGFILE_MONITOR}
+            sleep 60
+            start_builder_bidding
+        fi
+        sleep 5
+    done
+}
+
+start_builder_bidding() {
+    # Temporary no-op function until implementation is ready
+    echo "TODO: Implement start_builder_bidding"
+    return 0
+    
+    #TODO: adjust this according to the podman execution command
+    #start-stop-daemon -S --make-pidfile -p $PIDFILE -c $RBUILDER_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec
+    #    ${DAEMON} run /etc/rbuilder.config \
+    #    2>&1 | tee ${LOGFILE}"
+}
+
+start() {
+    echo -n "Starting $DESC: "
+    echo "Starting $DESC" > /var/volatile/system-api.fifo
+
+    # Ensure the rbuilder log file exists and has correct permissions
+    touch $LOGFILE
+    chown $RBUILDER_USER:$ETH_GROUP $LOGFILE
+
+    start_builder_bidding
+    echo "$NAME."
+
+    # Start the monitor in the background
+    monitor_and_restart &
+    echo $! > $PIDFILE_MONITOR
+}
+
+stop() {
+    echo "Stopping $DESC" > /var/volatile/system-api.fifo
+    local services="rbuilder monitor"
+    for service in $services; do
+        local pidfile_var="PIDFILE"
+        [ "$service" = "monitor" ] && pidfile_var="PIDFILE_MONITOR"
+
+        local pidfile=$(eval echo \$$pidfile_var)
+
+        echo "Stopping $service"
+        if [ -f "$pidfile" ]; then
+            local pid=$(cat "$pidfile")
+            local pids="$pid $(pgrep -P $pid)"
+
+            # Send SIGTERM to all processes
+            kill -TERM $pids 2>/dev/null
+
+            # Wait for processes to terminate
+            for i in $(seq 1 5); do
+                if ! kill -0 $pids 2>/dev/null; then
+                    break
+                fi
+                sleep 1
+            done
+
+            # Send SIGKILL to any remaining processes
+            kill -KILL $pids 2>/dev/null
+
+            rm -f "$pidfile"
+            echo "$service stopped"
+        else
+            echo "$pidfile not found, $service may not be running"
+        fi
+    done
+}
+
+case "$1" in
+  start)
+        start
+        ;;
+  stop)
+        stop
+        ;;
+  restart|reload)
+        stop
+        # gracefully wait for the services to stop
+        sleep 10
+        start
+        ;;
+  *)
+    N=/etc/init.d/$NAME
+    echo "Usage: $N {start|stop|restart|reload}" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/recipes-nodes/rbuilder-bidding/rbuilder-bidding.bb
+++ b/recipes-nodes/rbuilder-bidding/rbuilder-bidding.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "Rbuilder bidding service"
+LICENSE = "CLOSED"
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
+
+SRC_URI += "file://init"
+
+INITSCRIPT_NAME = "rbuilder-bidding"
+INITSCRIPT_PARAMS = "defaults 98"
+
+inherit update-rc.d
+
+do_install() {
+    install -d ${D}${sysconfdir}/init.d
+    install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/rbuilder-bidding
+}
+
+FILES:${PN} = "${sysconfdir}/init.d/${INITSCRIPT_NAME}"

--- a/recipes-nodes/rbuilder/rbuilder.inc
+++ b/recipes-nodes/rbuilder/rbuilder.inc
@@ -10,7 +10,7 @@ inherit cargo_bin update-rc.d useradd
 do_compile[network] = "1"
 
 DEPENDS += "libffi openssl eth-group protobuf-native"
-RDEPENDS:${PN} += "libffi openssl eth-group reth cvm-reverse-proxy-server cvm-reverse-proxy-client render-config"
+RDEPENDS:${PN} += "libffi openssl eth-group reth cvm-reverse-proxy-server cvm-reverse-proxy-client render-config rbuilder-bidding"
 
 export BINDGEN_EXTRA_CLANG_ARGS
 BINDGEN_EXTRA_CLANG_ARGS = "--sysroot=${WORKDIR}/recipe-sysroot -I${WORKDIR}/recipe-sysroot/usr/include"
@@ -23,11 +23,6 @@ S = "${WORKDIR}/git"
 
 INITSCRIPT_NAME = "rbuilder"
 INITSCRIPT_PARAMS = "defaults 98"
-
-FILES:${PN} += "${sysconfdir}/init.d/rbuilder"
-FILES:${PN} += "${sysconfdir}/rbuilder.config.mustache"
-FILES:${PN} += "${sysconfdir}/rbuilder.config"
-FILES:${PN} += "${sysconfdir}/rbuilder.ofac.json"
 
 USERADD_PACKAGES = "${PN}"
 USERADD_PARAM:${PN} = "-r -s /bin/false -G eth rbuilder"


### PR DESCRIPTION
- Added a skeleton recipe for the private bidding logic. @bakhtin will take it from here to fetch it from the private hub with a token and initiate the execution similar to the manual work done.
- The init script includes the bare minimum as well as a monitoring service which checks if the logic is terminated and restarts it. It might be not necessary if podman can take care of that.
- Removed duplicated entries from the original rbuilder recipe