### PR TITLE
update reth to v1.1.1

### DIFF
--- a/recipes-nodes/reth/reth_v1.1.1.bb
+++ b/recipes-nodes/reth/reth_v1.1.1.bb
@@ -1,0 +1,5 @@
+include reth.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}:"
+SRC_URI = "git://github.com/paradigmxyz/reth;protocol=https;branch=main"
+SRCREV = "v1.1.1"


### PR DESCRIPTION
This is a preparation PR to update reth to v1.1.1 once the rbuilder work is done.
It also updated the meta-rust-bin to the newest version that added rustc v1.82.0

![image](https://github.com/user-attachments/assets/1b09e2ab-f419-4b75-9440-bd5b28e981ad)
