### PR TITLE
Dropbear: bind to a non-default port, fix slow uploads

### DIFF
--- a/recipes-core/dropbear/dropbear/dropbear.default
+++ b/recipes-core/dropbear/dropbear/dropbear.default
@@ -1,3 +1,5 @@
 # -s: Disallow password logins
 # -g: Disable password logins for root
-DROPBEAR_EXTRA_ARGS="-s -g"
+# -p: Listen on non-default port
+# -W: Increase receive window buffer for faster uploads
+DROPBEAR_EXTRA_ARGS="-s -g -p 40192 -W 6291456"


### PR DESCRIPTION
Dropbear:
- Bind to a non-default port 40192
- Increase receive window buffer for faster uploads