### PR TITLE
Remove references to /persistent from the Lighthouse recipe

### DIFF
--- a/recipes-nodes/lighthouse/init
+++ b/recipes-nodes/lighthouse/init
@@ -65,8 +65,7 @@ start() {
 	chown $LIGHTHOUSE_USER:$ETH_GROUP $LOGFILE
 
 	# Ensure the LIGHTHOUSE_DIR exists and has correct permissions
-	mkdir -p $LIGHTHOUSE_DIR
-	chown -R $LIGHTHOUSE_USER:$ETH_GROUP $LIGHTHOUSE_DIR
+	install -d -m 0770 -o $LIGHTHOUSE_USER -g $ETH_GROUP $LIGHTHOUSE_DIR
 
 	# Remount /var/volatile with increased size
 	mount -o remount,size=90% /var/volatile

--- a/recipes-nodes/lighthouse/lighthouse.inc
+++ b/recipes-nodes/lighthouse/lighthouse.inc
@@ -114,22 +114,16 @@ do_install() {
     # Create the binary directory in the target root filesystem
     install -d ${D}${bindir}
     # Install the lighthouse binary
-    install -m 755 ${B}/${CARGO_TARGET_SUBDIR}/lighthouse ${D}${bindir}/lighthouse
+    install -m 0755 ${B}/${CARGO_TARGET_SUBDIR}/lighthouse ${D}${bindir}/lighthouse
     # Create the init script directory in the target root filesystem
     install -d ${D}${sysconfdir}/init.d
     # Install the init script
     install -m 0755 ${THISDIR}/init ${D}${sysconfdir}/init.d/lighthouse
-
-    # Create directory for lighthouse data and set permissions
-    install -d ${D}/persistent/lighthouse
-    chown lighthouse:eth ${D}/persistent/lighthouse
-    chmod 0770 ${D}/persistent/lighthouse
 }
 
 # Ensure do_install task is re-run if CARGO_TARGET_SUBDIR changes
 do_install[vardeps] += "CARGO_TARGET_SUBDIR"
 
 # Define the files to be included in the package
-FILES:${PN} += "/persistent/lighthouse"
 FILES:${PN} += "${bindir}/lighthouse"
 FILES:${PN} += "${sysconfdir}/init.d/lighthouse"


### PR DESCRIPTION
Remove references to `/persistent` from the Lighthouse recipe because this partition is only available in the runtime