### PR TITLE
Fixes for v1.2 release of the BuilderNet image

### DIFF
--- a/recipes-core/dropbear/dropbear/dropbear.default
+++ b/recipes-core/dropbear/dropbear/dropbear.default
@@ -1,5 +1,5 @@
 # -s: Disallow password logins
 # -g: Disable password logins for root
-# -p: Listen on non-default port
 # -W: Increase receive window buffer for faster uploads
-DROPBEAR_EXTRA_ARGS="-s -g -p 40192 -W 6291456"
+DROPBEAR_EXTRA_ARGS="-s -g -W 6291456"
+DROPBEAR_PORT=40192

--- a/recipes-core/dropbear/dropbear_%.bbappend
+++ b/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,3 +1,5 @@
+# Disable dropbear on all runlevels
+INITSCRIPT_PARAMS = "stop 10 S ."
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI:append = " file://dropbear.default"

--- a/recipes-nodes/haproxy/init
+++ b/recipes-nodes/haproxy/init
@@ -18,6 +18,7 @@ start_haproxy() {
     podman run -dt --rm --restart on-failure --name $NAME \
         -v /etc/haproxy:/usr/local/etc/haproxy:ro \
         --log-opt path=$LOGFILE --log-opt max-size=10mb \
+        --net host --cap-add=NET_BIND_SERVICE \
         docker.io/haproxy:$HAPROXY_VERSION
 }
 
@@ -27,6 +28,7 @@ start() {
     chmod 644 /etc/haproxy/haproxy.cfg
     mkdir -p /var/log/containers
     start_haproxy
+    chmod 644 $LOGFILE
     echo "$NAME."
 }
 

--- a/recipes-nodes/lighthouse/init
+++ b/recipes-nodes/lighthouse/init
@@ -38,7 +38,7 @@ start_lighthouse() {
 		start-stop-daemon -S --make-pidfile -p $PIDFILE -c $LIGHTHOUSE_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
 		bn \
 		--eth1 \
-		--checkpoint-sync-url https://mainnet.checkpoint.sigp.io \
+		--checkpoint-sync-url https://sync-mainnet.beaconcha.in \
 		--execution-endpoint http://localhost:8551 \
 		--execution-jwt $JWT_SECRET_FILE \
 		--suggested-fee-recipient ${SUGGESTED_FEE_RECIPIENT} \

--- a/recipes-nodes/rbuilder/config.mustache
+++ b/recipes-nodes/rbuilder/config.mustache
@@ -16,7 +16,7 @@ ignore_cancellable_orders = false
 jsonrpc_server_ip = "127.0.0.1"
 jsonrpc_server_port = 8645
 key_registration_url = "http://127.0.0.1:7937"
-live_builders = ["mgp-ordering", "mp-ordering", "mp-ordering-cb", "mp-ordering-deadline"]
+live_builders = ["mgp-ordering", "mp-ordering", "mp-ordering-cb", "mp-ordering-deadline","merging"]
 log_color = false
 log_json = true
 log_level = "info,rbuilder=debug"
@@ -76,3 +76,36 @@ discard_txs = true
 merge_wait_time_ms = 300
 name = "merging"
 num_threads = 3
+
+[[relays]]
+interval_between_submissions_ms = 250
+name = "flashbots"
+optimistic = false
+priority = 0
+url = "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"
+use_gzip_for_submit = false
+use_ssz_for_submit = true
+
+[[relays]]
+name = "ultrasound-us"
+optimistic = true
+priority = 1
+url = "https://relay-builders-us.ultrasound.money"
+use_gzip_for_submit = true
+use_ssz_for_submit = true
+
+[[relays]]
+name = "ultrasound-eu"
+optimistic = true
+priority = 1
+url = "https://relay-builders-eu.ultrasound.money"
+use_gzip_for_submit = true
+use_ssz_for_submit = true
+
+[[relays]]
+name = "agnostic"
+optimistic = true
+priority = 1
+url = "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net"
+use_gzip_for_submit = true
+use_ssz_for_submit = true

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -51,7 +51,6 @@ start() {
     chmod 770 $RETH_DIR/db
     chmod 660 $RETH_DIR/db/mdbx.lck
     chmod 660 $RETH_DIR/db/mdbx.dat
-    chmod 660 /tmp/reth.ipc
 
     mkdir -p $RBUILDER_PERSISTENT_DIR /var/run/rbuilder
     if [ ! -f $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json ]; then

--- a/recipes-nodes/rbuilder/rbuilder_v0.1.3.bb
+++ b/recipes-nodes/rbuilder/rbuilder_v0.1.3.bb
@@ -1,6 +1,6 @@
 include rbuilder.inc
 
 SRC_URI = "git://github.com/flashbots/rbuilder-operator;protocol=https;branch=main"
-SRCREV = "v0.1.2"
+SRCREV = "v0.1.3"
 
 PV = "1.0+git${SRCPV}"

--- a/recipes-nodes/render-config/fetch-config.sh
+++ b/recipes-nodes/render-config/fetch-config.sh
@@ -12,7 +12,7 @@
 set -e
 
 INIT_CONFIG_FILE="/etc/init-config.json"
-TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token"
+TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token /etc/haproxy/haproxy.cfg"
 TEMPLATED_CONFIG_FILES_UNSAFE="/etc/rbuilder-bidding/bidding-service.toml /etc/disk-encryption/key"
 OPTIONAL_TEMPLATES="/etc/disk-encryption/key"
 SYSTEM_API_FIFO=/var/volatile/system-api.fifo

--- a/recipes-nodes/render-config/fetch-config.sh
+++ b/recipes-nodes/render-config/fetch-config.sh
@@ -12,7 +12,7 @@
 set -e
 
 INIT_CONFIG_FILE="/etc/init-config.json"
-TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token /etc/haproxy/haproxy.cfg"
+TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token /etc/haproxy/haproxy.cfg /etc/td-agent-bit/aws-auth"
 TEMPLATED_CONFIG_FILES_UNSAFE="/etc/rbuilder-bidding/bidding-service.toml /etc/disk-encryption/key"
 OPTIONAL_TEMPLATES="/etc/disk-encryption/key"
 SYSTEM_API_FIFO=/var/volatile/system-api.fifo

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -60,6 +60,7 @@ start() {
     ) &
     echo $! > "$PIDFILE"
 
+    # Monitor the transfer progress. Periodically query rclone and report the stats to System API
     while kill -0 $(cat "$PIDFILE") 2>/dev/null; do
         curl -fSsL --retry 3 --retry-delay 2 --retry-connrefused \
             -H "Content-Type: application/json" \

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -64,7 +64,7 @@ start() {
         curl -fSsL --retry 3 --retry-delay 2 --retry-connrefused \
             -H "Content-Type: application/json" \
             -u "$RCLONE_RC_USERNAME:$RCLONE_RC_PASS" -d '{}' http://localhost:5572/core/stats | \
-            jq -r '"Reth snapshot sync status: Elapsed Time: \(.elapsedTime)s, ETA: \(.eta)s, Transferred: \(.bytes/1048576*100|round/100)/\(.totalBytes/1048576*100|round/100)MB, Speed: \(.speed/1048576*100|round/100)MB/s"' \
+            jq -r '"Reth snapshot sync status: Elapsed Time: \(.elapsedTime*100|round/100)s, ETA: \(.eta)s, Transferred: \(.bytes/1048576*100|round/100)/\(.totalBytes/1048576*100|round/100)MB, Speed: \(.speed/1048576*100|round/100)MB/s"' \
             > /var/volatile/system-api.fifo
         sleep 60
     done

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -17,6 +17,12 @@ RCLONE_CONFIG=/etc/rclone.conf
 RETH_DIR=/persistent/reth
 RETH_USER=reth
 ETH_GROUP=eth
+DAEMON=/usr/bin/rclone
+LATEST_META=$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
+DAEMON_ARGS="sync --config $RCLONE_CONFIG -v -P --transfers=20 --multi-thread-streams 30 \
+    --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
+    --delete-during --disable-http2 --no-gzip-encoding \
+    --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/$LATEST_META/ $RETH_DIR"
 
 log() {
     echo "$(date): $1" >> "$LOGFILE"
@@ -30,18 +36,10 @@ start() {
     touch "$LOGFILE"
     chown "$RETH_USER:$ETH_GROUP" "$LOGFILE"
 
-    # Ensure the RETH_DIR exists and has correct permissions
     mkdir -p "$RETH_DIR"
-    chown "$RETH_USER:$ETH_GROUP" "$RETH_DIR"
-
-    # Run the sync process as the reth user
-    LATEST_META=$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
-    echo "Latest meta: $LATEST_META"
-    rclone sync --config $RCLONE_CONFIG -v -P --transfers=20 --multi-thread-streams 30 \
-    --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
-    --delete-during --disable-http2 --no-gzip-encoding \
-    --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/$LATEST_META/ $RETH_DIR
-	echo "Reth is synced with the latest meta version: $LATEST_META" >> $LOGFILE 2>&1
+    log "Latest meta: $LATEST_META"
+    start-stop-daemon -S --make-pidfile -p $PIDFILE -m -b --exec /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> $LOGFILE 2>&1"
+	log "Reth is synced with the latest meta version: $LATEST_META" >> $LOGFILE 2>&1
 
     chown -R "$RETH_USER:$ETH_GROUP" "$RETH_DIR"
 }

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -18,11 +18,8 @@ RETH_DIR=/persistent/reth
 RETH_USER=reth
 ETH_GROUP=eth
 DAEMON=/usr/bin/rclone
-LATEST_META=$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
-DAEMON_ARGS="sync --config $RCLONE_CONFIG -v -P --transfers=20 --multi-thread-streams 30 \
-    --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
-    --delete-during --disable-http2 --no-gzip-encoding \
-    --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/$LATEST_META/ $RETH_DIR"
+RCLONE_RC_HTPASSWD_PATH=/tmp/rclone_rc_htpasswd
+PIDFILE=/var/run/$NAME.pid
 
 log() {
     echo "$(date): $1" >> "$LOGFILE"
@@ -32,16 +29,42 @@ log() {
 start() {
     log "Starting $DESC"
 
-    # Ensure the reth-sync log file exists and has correct permissions
     touch "$LOGFILE"
     chown "$RETH_USER:$ETH_GROUP" "$LOGFILE"
 
     mkdir -p "$RETH_DIR"
-    log "Latest meta: $LATEST_META"
-    start-stop-daemon -S --make-pidfile -p $PIDFILE -m -b --exec /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> $LOGFILE 2>&1"
-	log "Reth is synced with the latest meta version: $LATEST_META" >> $LOGFILE 2>&1
 
-    chown -R "$RETH_USER:$ETH_GROUP" "$RETH_DIR"
+    RCLONE_RC_USERNAME=admin
+    RCLONE_RC_PASS=$(openssl rand -hex 16)
+    install -m 600 <(printf "$RCLONE_RC_USERNAME:$(openssl passwd -apr1 $RCLONE_RC_PASS)\n") $RCLONE_RC_HTPASSWD_PATH
+
+    LATEST_META=$(rclone --config $RCLONE_CONFIG cat r2:chain-db-snapshots/reth-mainnet-full/latest_version.meta.txt)
+    log "Latest meta: $LATEST_META"
+
+    DAEMON_ARGS="sync --rc --rc-htpasswd $RCLONE_RC_HTPASSWD_PATH --config $RCLONE_CONFIG -v -P --transfers=20 --multi-thread-streams 30 \
+        --contimeout=10m --retries 10 --retries-sleep 60 --error-on-no-transfer --update --fast-list \
+        --delete-during --disable-http2 --no-gzip-encoding \
+        --exclude 'files.txt' r2:chain-db-snapshots/reth-mainnet-full/$LATEST_META/ $RETH_DIR"
+
+    (
+        $DAEMON $DAEMON_ARGS &> "$LOGFILE"
+        if [ $? -eq 0 ]; then
+            log "Reth sync completed successfully (version: $LATEST_META)"
+            chown -R "$RETH_USER:$ETH_GROUP" "$RETH_DIR"
+        else
+            log "Reth sync failed with exit code $?"
+        fi
+    ) &
+    echo $! > "$PIDFILE"
+
+    while kill -0 $(cat "$PIDFILE") 2>/dev/null; do
+        curl -fSsL --retry 3 --retry-delay 2 --retry-connrefused \
+            -H "Content-Type: application/json" \
+            -u "$RCLONE_RC_USERNAME:$RCLONE_RC_PASS" -d '{}' http://localhost:5572/core/stats | \
+            jq -r '"Reth snapshot sync status: Elapsed Time: \(.elapsedTime)s, ETA: \(.eta)s, Transferred: \(.bytes/1048576*100|round/100)/\(.totalBytes/1048576*100|round/100)MB, Speed: \(.speed/1048576*100|round/100)MB/s"' \
+            > /var/volatile/system-api.fifo
+        sleep 60
+    done
 }
 
 case "$1" in

--- a/recipes-nodes/reth-sync/init
+++ b/recipes-nodes/reth-sync/init
@@ -31,7 +31,10 @@ start() {
 
     touch "$LOGFILE"
     chown "$RETH_USER:$ETH_GROUP" "$LOGFILE"
-
+    if [ -f "$RETH_DIR/reth.toml" ]; then
+        log "Reth directory is not empty. Skipping chain snapshot sync."
+        exit 0
+    fi
     mkdir -p "$RETH_DIR"
 
     RCLONE_RC_USERNAME=admin

--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -57,6 +57,12 @@ start() {
     --log.file.max-files 0 \
     --metrics "127.0.0.1:9001" \
     2>&1 | tee ${LOGFILE}"
+
+  while [ ! -e /tmp/reth.ipc ]; do
+    sleep 1
+  done
+  chmod 660 /tmp/reth.ipc
+
   echo "$NAME."
 }
 
@@ -82,11 +88,6 @@ stop() {
     else
         echo "$PIDFILE not found, $NAME may not be running"
     fi
-
-    while [ ! -e /tmp/reth.ipc ]; do
-      sleep 1
-    done
-    chmod 660 /tmp/reth.ipc
 
     echo "$NAME stopped"
 }

--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -21,43 +21,43 @@ RETH_DIR=/persistent/reth
 JWT_SECRET_FILE=/var/volatile/jwt.hex
 
 start() {
-	echo -n "Starting $DESC: "
-	echo "Starting $DESC" > /var/volatile/system-api.fifo
+  echo -n "Starting $DESC: "
+  echo "Starting $DESC" > /var/volatile/system-api.fifo
 
-	# Ensure the reth log file exists and has correct permissions
-  	touch $LOGFILE
-  	chown $RETH_USER:$ETH_GROUP $LOGFILE
+  # Ensure the reth log file exists and has correct permissions
+    touch $LOGFILE
+    chown $RETH_USER:$ETH_GROUP $LOGFILE
 
-	# Ensure the RETH_DIR exists and has correct permissions
-	mkdir -p $RETH_DIR
-	chown -R $RETH_USER:$ETH_GROUP $RETH_DIR
+  # Ensure the RETH_DIR exists and has correct permissions
+  mkdir -p $RETH_DIR
+  chown -R $RETH_USER:$ETH_GROUP $RETH_DIR
 
-	# Check if the JWT_SECRET_FILE exists and exit with a message if it doesn't
-	if [ ! -f $JWT_SECRET_FILE ]; then
-		echo "JWT secret file not found at $JWT_SECRET_FILE. Exiting."
-		exit 1
-	fi
+  # Check if the JWT_SECRET_FILE exists and exit with a message if it doesn't
+  if [ ! -f $JWT_SECRET_FILE ]; then
+    echo "JWT secret file not found at $JWT_SECRET_FILE. Exiting."
+    exit 1
+  fi
 
-	start-stop-daemon -S --make-pidfile -p $PIDFILE -c $RETH_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
-		node \
-		--full \
-		--datadir "$RETH_DIR" \
-		--authrpc.addr 127.0.0.1 \
-		--authrpc.jwtsecret "$JWT_SECRET_FILE" \
-		--authrpc.port 8551 \
-		--http \
-		--http.addr 127.0.0.1 \
-		--http.port 8545 \
-		--http.api "eth,net,web3,trace,rpc,debug,txpool" \
-		--ws \
-		--ws.addr 127.0.0.1 \
-		--ws.port 8546 \
-		--ws.api "eth,net,trace,web3,rpc,debug,txpool" \
-		--log.stdout.format json \
-		--log.file.max-files 0 \
-		--metrics "127.0.0.1:9001" \
-		2>&1 | tee ${LOGFILE}"
-	echo "$NAME."
+  start-stop-daemon -S --make-pidfile -p $PIDFILE -c $RETH_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "exec ${DAEMON} \
+    node \
+    --full \
+    --datadir "$RETH_DIR" \
+    --authrpc.addr 127.0.0.1 \
+    --authrpc.jwtsecret "$JWT_SECRET_FILE" \
+    --authrpc.port 8551 \
+    --http \
+    --http.addr 127.0.0.1 \
+    --http.port 8545 \
+    --http.api "eth,net,web3,trace,rpc,debug,txpool" \
+    --ws \
+    --ws.addr 127.0.0.1 \
+    --ws.port 8546 \
+    --ws.api "eth,net,trace,web3,rpc,debug,txpool" \
+    --log.stdout.format json \
+    --log.file.max-files 0 \
+    --metrics "127.0.0.1:9001" \
+    2>&1 | tee ${LOGFILE}"
+  echo "$NAME."
 }
 
 stop() {
@@ -82,6 +82,12 @@ stop() {
     else
         echo "$PIDFILE not found, $NAME may not be running"
     fi
+
+    while [ ! -e /tmp/reth.ipc ]; do
+      sleep 1
+    done
+    chmod 660 /tmp/reth.ipc
+
     echo "$NAME stopped"
 }
 
@@ -97,9 +103,9 @@ case "$1" in
         start
         ;;
   *)
-	N=/etc/init.d/$NAME
-	echo "Usage: $N {start|stop|restart|reload}" >&2
-	exit 1
-	;;
+  N=/etc/init.d/$NAME
+  echo "Usage: $N {start|stop|restart|reload}" >&2
+  exit 1
+  ;;
 esac
 exit 0


### PR DESCRIPTION
Various fixes for v1.2 release of the BuilderNet image:
- Disable SSH by default by passing `INITSCRIPT_PARAMS` to the dropbear recipe (it can still be toggled through System API actions)
- Bind SSH to a non-standard port
- Fix missing capabilities for HAProxy container to allow binding to port 443
- Fix no longer working checkpoint sync URL for Lighthouse
- Update rbuilder config to include `merging` builder. Hardcode relays. Templating them makes it susceptible to exploitation by passing malformed input.
- Bump rbuilder to v0.1.3
- Add missing templates to the list of rendered templates
- Refactor reth-sync script: keep the main sync process running in background, run a monitor in foreground that continuously reports the download progress to System API. Once the main reth-sync PID is gone the foreground monitor shuts down continuing the rest of the boot sequence.
- Fix mixed tabs/spaces in the reth init file.