### PR TITLE
Bump rbuilder and rbuilder-bidding

### DIFF
--- a/recipes-nodes/rbuilder-bidding/init
+++ b/recipes-nodes/rbuilder-bidding/init
@@ -13,7 +13,7 @@ NAME=rbuilder-bidding
 DESC="Builder Bidding Service"
 LOGFILE=/var/log/containers/rbuilder-bidding.log
 RBUILDER_USER=rbuilder
-RBUILDER_BIDDING_VERSION=0.4.0@sha256:b2c13b6c0b2b2ad269c80ed66e5b54dda18eb9fa71acb22f82a2cdc745811cbd
+RBUILDER_BIDDING_VERSION=0.4.1@sha256:9a27046ad3d11a38c8f67c98dbc8fb59c2a545f18f2e809e5accdfe8df7d5b8b
 ETH_GROUP=eth
 
 source /etc/rbuilder-bidding/rbuilder-bidding-token

--- a/recipes-nodes/rbuilder/config.mustache
+++ b/recipes-nodes/rbuilder/config.mustache
@@ -16,7 +16,7 @@ ignore_cancellable_orders = false
 jsonrpc_server_ip = "127.0.0.1"
 jsonrpc_server_port = 8645
 key_registration_url = "http://127.0.0.1:7937"
-live_builders = ["mgp-ordering", "mp-ordering", "mp-ordering-cb", "mp-ordering-deadline","merging"]
+live_builders = ["mgp-ordering", "mp-ordering", "mp-ordering-cb", "mp-ordering-deadline"]
 log_color = false
 log_json = true
 log_level = "info,rbuilder=debug"
@@ -28,7 +28,6 @@ optimistic_relay_secret_key = "{{rbuilder.optimistic_relay_secret_key}}"
 relay_secret_key = "{{rbuilder.relay_secret_key}}"
 reth_db_path = "/persistent/reth/db"
 reth_static_files_path = "/persistent/reth/static_files"
-root_hash_task_pool_threads = 6
 root_hash_use_sparse_trie = true
 sbundle_mergeabe_signers = ["0xFC171C46A32DC7fF09fBDDD4884a65b2aD596517"]
 simulation_threads = 4
@@ -69,13 +68,6 @@ drop_failed_orders = true
 failed_order_retries = 1
 name = "mp-ordering-cb"
 sorting = "max-profit"
-
-[[builders]]
-algo = "merging-builder"
-discard_txs = true
-merge_wait_time_ms = 300
-name = "merging"
-num_threads = 3
 
 [[relays]]
 interval_between_submissions_ms = 250

--- a/recipes-nodes/rbuilder/rbuilder_v0.1.4.bb
+++ b/recipes-nodes/rbuilder/rbuilder_v0.1.4.bb
@@ -1,6 +1,6 @@
 include rbuilder.inc
 
 SRC_URI = "git://github.com/flashbots/rbuilder-operator;protocol=https;branch=main"
-SRCREV = "v0.1.3"
+SRCREV = "v0.1.4"
 
 PV = "1.0+git${SRCPV}"


### PR DESCRIPTION
- Bump rbuilder to v0.1.4
- Bump rbuilder-bidding-service to v0.4.1
- Removed no longer supported `merging` builder algorithm