### PR TITLE
Better handling of the rbuilder blocklist

### DIFF
--- a/recipes-nodes/rbuilder/config.mustache
+++ b/recipes-nodes/rbuilder/config.mustache
@@ -1,5 +1,5 @@
 bidding_service_ipc_path = "/var/run/rbuilder/rpc_bidding_server.sock"
-blocklist_file_path = "/persistent/rbuilder/rbuilder.blocklist.json"
+blocklist = "{{rbuilder.blocklist}}"
 blocks_processor_url = "https://orderflow-archive.flashbots.net/api"
 chain = "mainnet"
 cl_node_url = ["http://127.0.0.1:3500"]
@@ -26,6 +26,7 @@ optimistic_max_bid_value_eth = "10"
 optimistic_prevalidate_optimistic_blocks = false
 optimistic_relay_secret_key = "{{rbuilder.optimistic_relay_secret_key}}"
 relay_secret_key = "{{rbuilder.relay_secret_key}}"
+require_non_empty_blocklist = {{rbuilder.require_non_empty_blocklist}}
 reth_db_path = "/persistent/reth/db"
 reth_static_files_path = "/persistent/reth/static_files"
 root_hash_use_sparse_trie = true
@@ -69,35 +70,4 @@ failed_order_retries = 1
 name = "mp-ordering-cb"
 sorting = "max-profit"
 
-[[relays]]
-interval_between_submissions_ms = 250
-name = "flashbots"
-optimistic = false
-priority = 0
-url = "https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net"
-use_gzip_for_submit = false
-use_ssz_for_submit = true
-
-[[relays]]
-name = "ultrasound-us"
-optimistic = true
-priority = 1
-url = "https://relay-builders-us.ultrasound.money"
-use_gzip_for_submit = true
-use_ssz_for_submit = true
-
-[[relays]]
-name = "ultrasound-eu"
-optimistic = true
-priority = 1
-url = "https://relay-builders-eu.ultrasound.money"
-use_gzip_for_submit = true
-use_ssz_for_submit = true
-
-[[relays]]
-name = "agnostic"
-optimistic = true
-priority = 1
-url = "https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net"
-use_gzip_for_submit = true
-use_ssz_for_submit = true
+{{{rbuilder.relays}}}

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -53,10 +53,6 @@ start() {
     chmod 660 $RETH_DIR/db/mdbx.dat
 
     mkdir -p $RBUILDER_PERSISTENT_DIR /var/run/rbuilder
-    if [ ! -f $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json ]; then
-        echo "[]" > $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json
-        chmod 640 $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json
-    fi
     chown -R $RBUILDER_USER:$RBUILDER_USER /persistent/rbuilder /etc/rbuilder.config /var/run/rbuilder
     chmod 640 /etc/rbuilder.config
 

--- a/recipes-nodes/rbuilder/rbuilder_v0.1.5.bb
+++ b/recipes-nodes/rbuilder/rbuilder_v0.1.5.bb
@@ -1,6 +1,6 @@
 include rbuilder.inc
 
 SRC_URI = "git://github.com/flashbots/rbuilder-operator;protocol=https;branch=main"
-SRCREV = "v0.1.4"
+SRCREV = "v0.1.5"
 
 PV = "1.0+git${SRCPV}"

--- a/recipes-nodes/render-config/fetch-config.sh
+++ b/recipes-nodes/render-config/fetch-config.sh
@@ -12,8 +12,8 @@
 set -e
 
 INIT_CONFIG_FILE="/etc/init-config.json"
-TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rbuilder.config /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token /etc/haproxy/haproxy.cfg /etc/td-agent-bit/aws-auth"
-TEMPLATED_CONFIG_FILES_UNSAFE="/etc/rbuilder-bidding/bidding-service.toml /etc/disk-encryption/key"
+TEMPLATED_CONFIG_FILES="/etc/td-agent-bit/td-agent-bit.conf /etc/process-exporter/process-exporter.yaml /etc/prometheus/prometheus.yml /etc/rclone.conf /etc/orderflow-proxy.conf /etc/system-api/systemapi-config.toml /etc/rbuilder-bidding/rbuilder-bidding-token /etc/haproxy/haproxy.cfg /etc/td-agent-bit/aws-auth"
+TEMPLATED_CONFIG_FILES_UNSAFE="/etc/rbuilder-bidding/bidding-service.toml /etc/disk-encryption/key /etc/rbuilder.config"
 OPTIONAL_TEMPLATES="/etc/disk-encryption/key"
 SYSTEM_API_FIFO=/var/volatile/system-api.fifo
 


### PR DESCRIPTION
Bump rbuilder to v0.1.5 which has a better handling of the blocklist:
- Allow loading the blocklist from the URL
- A toggle to require a non-empty blocklist

Other changes:
- Remove creating a default empty blocklist on rbuilder service startup.
- Make relays section of rbuilder config configurable
- Make rbuilder config unsafe to render as it will contain `[[relays]]` section with new lines