### PR TITLE
Revert removal of emtpy blocklist creation

### DIFF
--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -53,6 +53,10 @@ start() {
     chmod 660 $RETH_DIR/db/mdbx.dat
 
     mkdir -p $RBUILDER_PERSISTENT_DIR /var/run/rbuilder
+    if [ ! -f $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json ]; then
+        echo "[]" > $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json
+        chmod 640 $RBUILDER_PERSISTENT_DIR/rbuilder.blocklist.json
+    fi
     chown -R $RBUILDER_USER:$RBUILDER_USER /persistent/rbuilder /etc/rbuilder.config /var/run/rbuilder
     chmod 640 /etc/rbuilder.config
 


### PR DESCRIPTION
Revert the changes from https://github.com/flashbots/meta-evm/pull/61/files#diff-1b9613527a68a64974034a69196953b572341af92125ddfefd0b044530b11abc to allow running rbuilder when no blocklist is required.