### PR TITLE
Sleep to fix reth socket permissions

### DIFF
--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -61,6 +61,9 @@ start() {
   while [ ! -e /tmp/reth.ipc ]; do
     sleep 1
   done
+
+  echo "Sleeping to fix socket permissions after reth has started..."
+  sleep 5
   chmod 660 /tmp/reth.ipc
 
   echo "$NAME."


### PR DESCRIPTION
After some testing I revealed a race condition in the Reth service init script. 

We start Reth in the background with `start-stop-daemon`, wait for IPC socket to appear, and fix its permissions to allow shared access to Rbuilder. But it seems there is a race condition as Reth reverts the IPC socket permissions after we fixed it with `chmod`. It happens a couple of seconds after Reth starts and creates a IPC socket.

This PR introduces additional 5 seconds sleep to enable Reth to set IPC socket permissions before we `chmod` it later.