### PR TITLE
Fixes for v1.3 release

### DIFF
--- a/recipes-nodes/haproxy/init
+++ b/recipes-nodes/haproxy/init
@@ -11,7 +11,8 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=haproxy
 DESC="HAProxy Service"
-LOGFILE=/var/log/containers/haproxy.log
+LOG_DIR=/var/log/containers
+LOGFILE="$LOG_DIR/haproxy.log"
 HAPROXY_VERSION=3.0.6@sha256:0f3127e63b00982c3f12b2a9a17ecbd0595003a191ec1cb403741a692f7a39a9
 
 start_haproxy() {
@@ -26,7 +27,7 @@ start() {
     echo -n "Starting $DESC: "
     echo "Starting $DESC" > /var/volatile/system-api.fifo
     chmod 644 /etc/haproxy/haproxy.cfg
-    mkdir -p /var/log/containers
+    install -d -m 755 $LOG_DIR
     start_haproxy
     chmod 644 $LOGFILE
     echo "$NAME."

--- a/recipes-nodes/lighthouse/init
+++ b/recipes-nodes/lighthouse/init
@@ -53,7 +53,7 @@ start_lighthouse() {
 		--metrics-address 127.0.0.1 \
 		--metrics-port 5054 \
 		--datadir "$LIGHTHOUSE_DIR" \
-		2>&1 | tee ${LOGFILE}"
+		2>&1 | tee -a ${LOGFILE}"
 }
 
 start() {

--- a/recipes-nodes/orderflow-proxy/orderflow-proxy_v0.3.0.bb
+++ b/recipes-nodes/orderflow-proxy/orderflow-proxy_v0.3.0.bb
@@ -12,7 +12,7 @@ GO_IMPORT = "github.com/flashbots/tdx-orderflow-proxy"
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main \
            file://orderflow-proxy-init \
            file://orderflow-proxy.conf.mustache"
-SRCREV = "v0.2.8"
+SRCREV = "v0.3.0"
 
 GO_INSTALL = "${GO_IMPORT}/cmd/receiver-proxy"
 GO_LINKSHARED = ""

--- a/recipes-nodes/rbuilder-bidding/init
+++ b/recipes-nodes/rbuilder-bidding/init
@@ -11,9 +11,11 @@
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 NAME=rbuilder-bidding
 DESC="Builder Bidding Service"
-LOGFILE=/var/log/containers/rbuilder-bidding.log
+LOG_DIR=/var/log/containers
+LOGFILE="$LOG_DIR/rbuilder-bidding.log"
+RUN_DIR=/var/run/rbuilder
 RBUILDER_USER=rbuilder
-RBUILDER_BIDDING_VERSION=0.4.3@sha256:49b6c9cd1e68efd513a61d29d002777b35df0003b98a06c106d7c56614e8c6dd
+RBUILDER_BIDDING_VERSION=1.0.0@sha256:dbcb871373c7b0a0095544c994930ccff8e2013195b1143ccf25b6f6ab18ea88
 ETH_GROUP=eth
 
 source /etc/rbuilder-bidding/rbuilder-bidding-token
@@ -21,9 +23,9 @@ source /etc/rbuilder-bidding/rbuilder-bidding-token
 start_builder_bidding() {
     podman run -dt --rm --restart on-failure --name $NAME \
         -v /etc/rbuilder-bidding:/rbuilder-bidding \
-        -v /var/run/rbuilder:/var/run/rbuilder \
+        -v $RUN_DIR:$RUN_DIR \
         --user $(id -u rbuilder):$(id -g rbuilder) \
-        --log-opt path=$LOGFILE --log-opt max-size=10mb \
+        --log-opt path=$LOGFILE \
         ghcr.io/flashbots/rbuilder-bidding-service:$RBUILDER_BIDDING_VERSION /rbuilder-bidding/bidding-service.toml
 }
 
@@ -31,16 +33,13 @@ start() {
     echo -n "Starting $DESC: "
     echo "Starting $DESC" > /var/volatile/system-api.fifo
 
-    # Ensure the rbuilder log file exists and has correct permissions
-    touch $LOGFILE
-    chown $RBUILDER_USER:$ETH_GROUP $LOGFILE
-
     echo $GITHUB_TOKEN | podman login ghcr.io -u flashbots --password-stdin
 
-    mkdir -p /var/run/rbuilder /var/log/containers
-    chown -R $RBUILDER_USER:$RBUILDER_USER /var/run/rbuilder
+    install -d -m 755 $LOG_DIR $RUN_DIR
+    chown -R $RBUILDER_USER:$RBUILDER_USER $RUN_DIR
 
     start_builder_bidding
+    chmod 644 $LOGFILE
     echo "$NAME."
 }
 

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -37,7 +37,7 @@ monitor_and_restart() {
 start_builder() {
     start-stop-daemon -S --make-pidfile -p $PIDFILE -c $RBUILDER_USER:$ETH_GROUP -N -10 -b -a /bin/sh -- -c "ulimit -n $ULIMIT_FD; exec
         ${DAEMON} run /etc/rbuilder.config \
-        2>&1 | tee ${LOGFILE}"
+        2>&1 | tee -a ${LOGFILE}"
 }
 
 start() {

--- a/recipes-nodes/rbuilder/rbuilder_v1.0.0.bb
+++ b/recipes-nodes/rbuilder/rbuilder_v1.0.0.bb
@@ -1,6 +1,6 @@
 include rbuilder.inc
 
 SRC_URI = "git://github.com/flashbots/rbuilder-operator;protocol=https;branch=main"
-SRCREV = "v0.1.6"
+SRCREV = "v1.0.0"
 
 PV = "1.0+git${SRCPV}"

--- a/recipes-nodes/reth/init
+++ b/recipes-nodes/reth/init
@@ -56,7 +56,7 @@ start() {
     --log.stdout.format json \
     --log.file.max-files 0 \
     --metrics "127.0.0.1:9001" \
-    2>&1 | tee ${LOGFILE}"
+    2>&1 | tee -a ${LOGFILE}"
 
   while [ ! -e /tmp/reth.ipc ]; do
     sleep 1


### PR DESCRIPTION
- Fix container log files have permissions preventing FluentBit from reading it
- Fix init scripts holding exclusive lock on the log files (`tee`) and preventing `logrotate` from truncating it. Adding `tee -a` makes the lock non-exclusive.

Bump software versions:
- of-proxy to v.0.3.0
- rbuilder-bidding to v1.0.0
- rbuilder-operator to v1.0.0
