### PR TITLE
Bump of-proxy to 0.3.1

### DIFF
--- a/recipes-nodes/orderflow-proxy/files/orderflow-proxy.conf.mustache
+++ b/recipes-nodes/orderflow-proxy/files/orderflow-proxy.conf.mustache
@@ -1,10 +1,10 @@
 export LOG_JSON=true
 export FLASHBOTS_ORDERFLOW_SIGNER_ADDRESS={{orderflow_proxy.flashbots_orderflow_signing_address}}
-export LOCAL_LISTEN_ADDR={{orderflow_proxy.local_listen_addr}}
-export PUBLIC_LISTEN_ADDR={{orderflow_proxy.public_listen_addr}}
+export USER_LISTEN_ADDR={{orderflow_proxy.user_listen_addr}}
+export SYSTEM_LISTEN_ADDR={{orderflow_proxy.system_listen_addr}}
 export BUILDER_ENDPOINT={{orderflow_proxy.builder_endpoint}}
 export CERT_HOSTS=localhost,127.0.0.1,{{public_ip}},{{dns_name}}
 export BUILDER_CONFIGHUB_ENDPOINT={{orderflow_proxy.builder_confighub_endpoint}}
 export ORDERFLOW_ARCHIVE_ENDPOINT={{orderflow_proxy.orderflow_archive_endpoint}}
 export CONN_PER_PEER={{orderflow_proxy.conn_per_peer}}
-export MAX_LOCAL_RPS={{orderflow_proxy.max_local_rps}}
+export MAX_USER_RPS={{orderflow_proxy.max_user_rps}}

--- a/recipes-nodes/orderflow-proxy/orderflow-proxy_v0.3.1.bb
+++ b/recipes-nodes/orderflow-proxy/orderflow-proxy_v0.3.1.bb
@@ -12,7 +12,7 @@ GO_IMPORT = "github.com/flashbots/tdx-orderflow-proxy"
 SRC_URI = "git://${GO_IMPORT};protocol=https;branch=main \
            file://orderflow-proxy-init \
            file://orderflow-proxy.conf.mustache"
-SRCREV = "v0.3.0"
+SRCREV = "v0.3.1"
 
 GO_INSTALL = "${GO_IMPORT}/cmd/receiver-proxy"
 GO_LINKSHARED = ""


### PR DESCRIPTION
- Bump of-proxy to 0.3.1
- Rename of-proxy parameters, caused by https://github.com/flashbots/buildernet-orderflow-proxy/pull/32