### PR TITLE
Fix rbuilder status watchdog cronjob permissions

### DIFF
--- a/recipes-nodes/rbuilder-status-watchdog/rbuilder-status-watchdog.bb
+++ b/recipes-nodes/rbuilder-status-watchdog/rbuilder-status-watchdog.bb
@@ -17,7 +17,7 @@ do_install() {
   install -m 0755 ${S}/rbuilder-status-watchdog.sh ${D}${sysconfdir}/init.d/rbuilder-status-watchdog
 
   # Install a cron job
-  install -m 0755 ${WORKDIR}/rbuilder-status-watchdog.cron ${D}${sysconfdir}/cron.d/rbuilder-status-watchdog
+  install -m 0640 ${WORKDIR}/rbuilder-status-watchdog.cron ${D}${sysconfdir}/cron.d/rbuilder-status-watchdog
 }
 
 RDEPENDS:${PN} += "jq curl coreutils rbuilder"


### PR DESCRIPTION
Cronjob file should not be executable, otherwise crond ignores it.