### PR TITLE
add dropbear flags disabling port forwarding

### DIFF
--- a/recipes-core/dropbear/dropbear/dropbear.default
+++ b/recipes-core/dropbear/dropbear/dropbear.default
@@ -1,5 +1,8 @@
 # -s: Disallow password logins
 # -g: Disable password logins for root
+# -m: Don't display the message of the day on login
+# -j: Disable local port forwarding
+# -k: Disable remote port forwarding
 # -W: Increase receive window buffer for faster uploads
-DROPBEAR_EXTRA_ARGS="-s -g -W 6291456"
+DROPBEAR_EXTRA_ARGS="-s -g -m -j -k -W 6291456"
 DROPBEAR_PORT=40192


### PR DESCRIPTION
This is a default deny port forwarding setting for the dropbear.