### PR TITLE
Serve Let's Encrypt certificate through CVM proxy

### DIFF
--- a/recipes-nodes/acme-le/post-hook.sh
+++ b/recipes-nodes/acme-le/post-hook.sh
@@ -40,3 +40,7 @@ chmod 644 "$METRICS_FILE"
 
 # Create a symlink to the private key so acme.sh can find it
 ln -fsr "$PRIV_KEY" "$(dirname $CERT_PATH)/${MAIN_DOMAIN}.key"
+
+# Copy Let's Encrypt certificate to HAProxy certs directory to serve
+# it through CVM proxy.
+install -m 644 --no-target-directory "$CERT_PATH" /etc/haproxy/certs/le.cer

--- a/recipes-nodes/acme-le/post-hook.sh
+++ b/recipes-nodes/acme-le/post-hook.sh
@@ -43,4 +43,4 @@ ln -fsr "$PRIV_KEY" "$(dirname $CERT_PATH)/${MAIN_DOMAIN}.key"
 
 # Copy Let's Encrypt certificate to HAProxy certs directory to serve
 # it through CVM proxy.
-install -m 644 --no-target-directory "$CERT_PATH" /etc/haproxy/certs/le.cer
+install -m 644 --no-target-directory "$CERT_PATH" /etc/haproxy/static/le.cer

--- a/recipes-nodes/haproxy/haproxy.bb
+++ b/recipes-nodes/haproxy/haproxy.bb
@@ -20,10 +20,10 @@ do_install() {
     install -d -m 0755 ${D}${sysconfdir}/haproxy/certs ${D}${sysconfdir}/haproxy/html
     install -m 0755 ${WORKDIR}/init ${D}${sysconfdir}/init.d/haproxy
     install -m 0644 ${THISDIR}/haproxy.cfg.mustache ${D}${sysconfdir}/haproxy/haproxy.cfg.mustache
-    install -m 0644 ${THISDIR}/index.html ${D}${sysconfdir}/haproxy/html/index.html
+    install -m 0644 ${THISDIR}/index.html ${D}${sysconfdir}/haproxy/static/index.html
 }
 
 FILES:${PN} = "${sysconfdir}/init.d/${INITSCRIPT_NAME} \
                ${sysconfdir}/haproxy/certs \
                ${sysconfdir}/haproxy/haproxy.cfg.mustache \
-               ${sysconfdir}/haproxy/html/index.html"
+               ${sysconfdir}/haproxy/static/index.html"

--- a/recipes-nodes/haproxy/haproxy.cfg.mustache
+++ b/recipes-nodes/haproxy/haproxy.cfg.mustache
@@ -52,7 +52,7 @@ frontend default
 
   http-request return status 200 content-type text/plain string "OK\n" if { path '/livez' }
   http-request return status 200 content-type text/plain string "${ACCOUNT_URL}\n" if { path '/acme-account-url' }
-  http-request return status 200 content-type text/html file "/usr/local/etc/haproxy/html/index.html" hdr "cache-control" "max-age=604800" if { method GET } { path / }
+  http-request return status 200 content-type text/html file "/usr/local/etc/haproxy/static/index.html" hdr "cache-control" "max-age=604800" if { method GET } { path / }
 
   default_backend user_of
 
@@ -67,7 +67,7 @@ frontend prometheus
 
 frontend public_cert
   bind 127.0.0.1:14727
-  http-request return status 200 content-type text/html file "/usr/local/etc/haproxy/certs/le.cer" hdr "cache-control" "max-age=604800"
+  http-request return status 200 content-type text/plain file "/usr/local/etc/haproxy/static/le.cer"
 
 backend user_of
   http-reuse always

--- a/recipes-nodes/haproxy/haproxy.cfg.mustache
+++ b/recipes-nodes/haproxy/haproxy.cfg.mustache
@@ -62,12 +62,14 @@ frontend system
 
 frontend prometheus
   bind 127.0.0.1:8405
-  mode http
   http-request use-service prometheus-exporter if { path /metrics }
   no log
 
+frontend public_cert
+  bind 127.0.0.1:14727
+  http-request return status 200 content-type text/html file "/usr/local/etc/haproxy/certs/le.cer" hdr "cache-control" "max-age=604800"
+
 backend user_of
-  mode http
   http-reuse always
 
   option httpchk GET /livez
@@ -75,7 +77,6 @@ backend user_of
   server user_of1 127.0.0.1:5543 check inter 5s fall 3 rise 1
 
 backend system_of
-  mode http
   http-reuse always
 
   option httpchk GET /livez


### PR DESCRIPTION
Update HAProxy config to serve a certificate issued by Let's Encrypt locally on port 14727. Previously, of-proxy served it but it no longer terminates TLS traffic. This is to maintain a working `https://_BUILDERNET_INSTANCE_:7936/cert` endpoint.