### PR TITLE
Bump file descriptors limit for rbuilder and of-proxy

### DIFF
--- a/recipes-nodes/orderflow-proxy/files/orderflow-proxy-init
+++ b/recipes-nodes/orderflow-proxy/files/orderflow-proxy-init
@@ -14,7 +14,7 @@ NAME=orderflow-proxy
 DESC="Orderflow Proxy"
 PIDFILE=/var/run/$NAME.pid
 LOGFILE=/var/log/$NAME.log
-ULIMIT_FD=65536
+ULIMIT_FD=1048576
 OF_PROXY_DIR=/persistent/orderflow-proxy
 
 source /etc/orderflow-proxy.conf

--- a/recipes-nodes/rbuilder/init
+++ b/recipes-nodes/rbuilder/init
@@ -21,7 +21,7 @@ RBUILDER_PERSISTENT_DIR=/persistent/rbuilder
 ETH_GROUP=eth
 RETH_DIR=/persistent/reth
 RETH_USER=reth
-ULIMIT_FD=65536
+ULIMIT_FD=1048576
 
 source /etc/rbuilder.env
 


### PR DESCRIPTION
Bump file descriptors limit to the allowed per process maximum for rbuilder and of-proxy. On rbuilder this should fix "Too many open files" error. On of-proxy it should potentially improve the orderflow latency